### PR TITLE
Implement networking infra and fix config loading

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -49,9 +49,13 @@ jobs:
     - name: Build
       run: go build -v ./...
       working-directory: go
+
+    - name: Set Project Root
+      run: echo "PROJECT_ROOT=$(pwd)" >> $GITHUB_ENV
+
+    - name: Use Project Root
+      run: echo "The project root is $PROJECT_ROOT"
   
     - name: Test
-      env:
-        PROJECT_ROOT: /app/
       run: go test -v ./...
       working-directory: go

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -7,6 +7,8 @@ on:
   pull_request:
     branches:
       - '**'
+env:
+  PROJECT_ROOT: /app/
 
 jobs:
   setup-and-test:
@@ -49,5 +51,7 @@ jobs:
       working-directory: go
   
     - name: Test
+      env:
+        PROJECT_ROOT: /app/
       run: go test -v ./...
       working-directory: go

--- a/Dockerfile
+++ b/Dockerfile
@@ -42,6 +42,8 @@ RUN make clean && make all
 # just to test things out
 RUN apt update && apt install -y iputils-ping
 
+ENV PROJECT_ROOT=/app
+
 # expose all the ports we may use
 #EXPOSE 50000-69999
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -39,6 +39,9 @@ RUN go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@v1.2
 # now that we've installed pre-reqs, build everything
 RUN make clean && make all
 
+# just to test things out
+RUN apt update && apt install -y iputils-ping
+
 # expose all the ports we may use
 #EXPOSE 50000-69999
 

--- a/README.md
+++ b/README.md
@@ -7,14 +7,59 @@ Currently a work in progress. By the end of this project, you should be able to 
 
 ## Automatic deployment
 
-You can automatically deploy the worker + GCS + global scheduler nodes by doing:
+You can automatically deploy the entire cluster (workers, GCS, global scheduler nodes) by following these instructions.
+
+First, build the `ray-node` Docker image:
+
+```bash
+docker build -t ray-node .
+```
+
+You should see Docker successively build each layer of the image, ending with something like `[+] Building 39.0s (19/19) FINISHED`.
+
+Next, spin up the cluster:
 
 ```bash
 docker-compose up
 ```
 
-Reset by doing ^C and then running `docker-compose down` to make sure all the containers are killed.
+Now, your cluster should be running! Let's test out if a node can talk to another node. Note that these commands will now be run-specific, since Docker containers are ID'd  randomly. First, list the container ID's of our cluster with `docker ps`. We'll get something like:
 
+```
+CONTAINER ID   IMAGE                            COMMAND                  CREATED         STATUS         PORTS                      NAMES
+c20387bbd534   ray-node                         "/bin/sh -c './go/bi…"   3 seconds ago   Up 2 seconds   0.0.0.0:50004->50004/tcp   babyray_worker3_1
+dce69f377b01   ray-node                         "/bin/sh -c ./go/bin…"   3 seconds ago   Up 2 seconds   0.0.0.0:50001->50001/tcp   babyray_global_scheduler_1
+e06583f90acd   ray-node                         "/bin/sh -c './go/bi…"   3 seconds ago   Up 2 seconds   0.0.0.0:50002->50002/tcp   babyray_worker1_1
+1d2559b0bb90   ray-node                         "/bin/sh -c './go/bi…"   3 seconds ago   Up 2 seconds   0.0.0.0:50003->50003/tcp   babyray_worker2_1
+c3781cf7bbce   ray-node                         "/bin/sh -c './go/bi…"   3 seconds ago   Up 2 seconds   0.0.0.0:50000->50000/tcp   babyray_gcs_1
+```
+
+Now, pick one of those container ID's---here we pick worker 1---and run an interactive shell on it:
+
+```bash
+docker exec -it e06583f90acd  /bin/bash
+```
+
+Then, run the command `ping node0` and you'll get something like:
+
+```
+docker exec -it e06583f90acd  /bin/bash
+root@e06583f90acd:/app# ping node0
+PING node0 (172.24.0.2) 56(84) bytes of data.
+64 bytes from babyray_gcs_1.babyray_mynetwork (172.24.0.2): icmp_seq=1 ttl=64 time=3.11 ms
+64 bytes from babyray_gcs_1.babyray_mynetwork (172.24.0.2): icmp_seq=2 ttl=64 time=0.499 ms
+64 bytes from babyray_gcs_1.babyray_mynetwork (172.24.0.2): icmp_seq=3 ttl=64 time=0.470 ms
+64 bytes from babyray_gcs_1.babyray_mynetwork (172.24.0.2): icmp_seq=4 ttl=64 time=0.348 ms
+64 bytes from babyray_gcs_1.babyray_mynetwork (172.24.0.2): icmp_seq=5 ttl=64 time=0.224 ms
+64 bytes from babyray_gcs_1.babyray_mynetwork (172.24.0.2): icmp_seq=6 ttl=64 time=0.268 ms
+64 bytes from babyray_gcs_1.babyray_mynetwork (172.24.0.2): icmp_seq=7 ttl=64 time=0.173 ms
+```
+
+Packets are flowing between worker 1 and the GCS!
+
+### Shut down the cluster
+
+Reset by doing ^C in the `docker-compose up` session and then running `docker-compose down` to make sure all the containers are killed and the network is deleted.
 
 ## Run a single node
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,30 +4,56 @@ services:
   gcs:
     image: ray-node
     command: ["/bin/sh", "-c", "./go/bin/gcsfunctable & ./go/bin/gcsobjtable"]
+    networks:
+        mynetwork:
+            aliases:
+                - node0
     ports:
       - "50000:50000"
 
   global_scheduler:
     image: ray-node
-    command: ["/bin/sh", "-c", "./go/bin/globalscheduler &"]
+    command: ["/bin/sh", "-c", "./go/bin/globalscheduler"]
+    networks:
+        mynetwork:
+            aliases:
+                - node1
     ports:
       - "50001:50001"
 
   worker1:
     image: ray-node
     command: ["/bin/sh", "-c", "./go/bin/localscheduler & ./go/bin/localobjstore"]
+    networks:
+        mynetwork:
+            aliases:
+                - node2
+    #entrypoint: /bin/bash
+    #command: >
+    #  -c "apt update && apt install -y iputils-ping && ping node0"
     ports:
       - "50002:50002"
 
   worker2:
     image: ray-node
     command: ["/bin/sh", "-c", "./go/bin/localscheduler & ./go/bin/localobjstore"]
+    networks:
+        mynetwork:
+            aliases:
+                - node3
     ports:
       - "50003:50003"
 
   worker3:
     image: ray-node
     command: ["/bin/sh", "-c", "./go/bin/localscheduler & ./go/bin/localobjstore"]
+    networks:
+        mynetwork:
+            aliases:
+                - node4
     ports:
       - "50004:50004"
 
+networks:
+    mynetwork:
+        driver: bridge

--- a/go/config/config.go
+++ b/go/config/config.go
@@ -43,7 +43,13 @@ func LoadConfig() *Config {
     }
 
     // Construct the path to the configuration file
+    rootPath := os.Getenv("PROJECT_ROOT")
+    // _ = rootPath
+    log.Printf("%v", rootPath)
+    log.Printf("%v", cwd)
+    log.Printf("ROOT IS: %v", filepath.Join(rootPath, "config", "app_config.yaml"))
     configFile := filepath.Join(cwd, "..", "..", "..", "config", "app_config.yaml")
+    // configFile := filepath.Join(rootPath, "config", "app_config.yaml")
 
     yamlFile, err := ioutil.ReadFile(configFile)
     if err != nil {

--- a/go/config/config.go
+++ b/go/config/config.go
@@ -34,22 +34,11 @@ type Config struct {
 func LoadConfig() *Config {
     var config Config
 
-    // Get the working directory of the executable. Key assumption here is that
-    // the executable is located at go/cmd/*/[executable]. Otherwise this will
-    // break.
-    cwd, err := os.Getwd()
-    if err != nil {
-        log.Fatalf("Failed to get current working directory: %v", err)
-    }
-
-    // Construct the path to the configuration file
+    // Construct the path to the configuration file. PROJECT_ROOT should somehow
+    // be set prior to any Go code execution (i.e., in GitHub Actions workflow
+    // before unit tests are run or in Dockerfile)
     rootPath := os.Getenv("PROJECT_ROOT")
-    // _ = rootPath
-    log.Printf("%v", rootPath)
-    log.Printf("%v", cwd)
-    log.Printf("ROOT IS: %v", filepath.Join(rootPath, "config", "app_config.yaml"))
-    configFile := filepath.Join(cwd, "..", "..", "..", "config", "app_config.yaml")
-    // configFile := filepath.Join(rootPath, "config", "app_config.yaml")
+    configFile := filepath.Join(rootPath, "config", "app_config.yaml")
 
     yamlFile, err := ioutil.ReadFile(configFile)
     if err != nil {


### PR DESCRIPTION
Implemented networking infra. This means:

- setting up DNS aliases and shared network
- adding `ping` so that we can test it out
- revamp README to provide instructions on flow to check that this is all working

Also fixed config file loading discrepancy between docker-compose and GitHub Actions. Previously the unit tests all passed and
```
configFile := filepath.Join(cwd, "..", "..", "..", "config", "app_config.yaml")
```
embedded the implicit assumption that execution was happening in `go/cmd/[...]/`. So when you did `docker-compose up`, the code would fail to find the YAML file.

We are now using environment variables to track this.