### PR TITLE
Smoothen deployment process + multi-stage builds for different node types

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,8 @@
-# Use the official Golang image to create a build artifact.
-# This is based on Debian and includes the Go toolset.
-FROM golang
-#:1.19
-#FROM golang:1.22
-#FROM debian:buster
-# as builder
+# Declare the CONFIG argument at the beginning
+ARG CONFIG=base
+
+# Base stage for common setup
+FROM golang as base
 
 RUN apt update
 RUN apt install -y protobuf-compiler
@@ -35,18 +33,24 @@ RUN python3 -m pip install grpcio-tools --break-system-packages
 RUN go install google.golang.org/protobuf/cmd/protoc-gen-go@v1.28
 RUN go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@v1.2
 
-
 # now that we've installed pre-reqs, build everything
-RUN make clean && make all
+RUN make clean && make go && make py && make build
 
 # just to test things out
 RUN apt update && apt install -y iputils-ping
 
 ENV PROJECT_ROOT=/app
 
-# expose all the ports we may use
-#EXPOSE 50000-69999
+FROM base as driver
 
-# placeholder commands
-#CMD ["./bin/localobjstore", "&", "./bin/localscheduler", "&", "./bin/worker"]
+# install necessary Python packages to run anything
+RUN python3 -m pip install dill --break-system-packages
+RUN cd python && python3 -m pip install -e . --break-system-packages
 
+# install basic necessities to actually do driver stuff
+RUN apt install -y nano
+
+
+# take in a CONFIG argument which will tell us what to target (GCS, global scheduler, or worker)
+# using multi-stage builds: https://chat.openai.com/share/a5eb4076-e36a-4a1e-b4c8-9d56ea7a604e
+FROM ${CONFIG} as final

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
-.PHONY: all go py clean build servers
+.PHONY: all go py clean build servers docker
 
-all: go py build
+all: go py build docker
 
 go: proto
 	@echo "Generating Go gRPC code..."
@@ -12,7 +12,6 @@ py: proto
 	@echo "Modifying import statements for relative imports..."
 	# below line is now compatible with both MacOS (BSD) and GNU
 	sed -i'' -e 's/import rayclient_pb2 as rayclient__pb2/from . import rayclient_pb2 as rayclient__pb2/' python/babyray/rayclient_pb2_grpc.py
-
 
 build: servers
 
@@ -41,6 +40,10 @@ localscheduler:
 worker:
 	@echo "Building Worker Server..."
 	cd go && go build -o bin/worker cmd/worker/main.go
+
+docker:
+	docker build --build-arg CONFIG=base -t ray-node:base .
+	docker build --build-arg CONFIG=driver -t ray-node:driver .
 
 clean:
 	@echo "Cleaning up..."

--- a/README.md
+++ b/README.md
@@ -9,13 +9,13 @@ Currently a work in progress. By the end of this project, you should be able to 
 
 You can automatically deploy the entire cluster (workers, GCS, global scheduler nodes) by following these instructions.
 
-First, build the `ray-node` Docker image:
+First, build everything:
 
 ```bash
-docker build -t ray-node .
+make all
 ```
 
-You should see Docker successively build each layer of the image, ending with something like `[+] Building 39.0s (19/19) FINISHED`.
+This will generate the Go and Python gRPC stub files, compile the Go server code, and build the Docker images we need to deploy the cluster.
 
 Next, spin up the cluster:
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3'
 
 services:
   gcs:
-    image: ray-node
+    image: ray-node:base
     command: ["/bin/sh", "-c", "./go/bin/gcsfunctable & ./go/bin/gcsobjtable"]
     networks:
         mynetwork:
@@ -12,7 +12,7 @@ services:
       - "50000:50000"
 
   global_scheduler:
-    image: ray-node
+    image: ray-node:base
     command: ["/bin/sh", "-c", "./go/bin/globalscheduler"]
     networks:
         mynetwork:
@@ -22,7 +22,7 @@ services:
       - "50001:50001"
 
   worker1:
-    image: ray-node
+    image: ray-node:driver
     command: ["/bin/sh", "-c", "./go/bin/localscheduler & ./go/bin/localobjstore"]
     networks:
         mynetwork:
@@ -35,7 +35,7 @@ services:
       - "50002:50002"
 
   worker2:
-    image: ray-node
+    image: ray-node:driver
     command: ["/bin/sh", "-c", "./go/bin/localscheduler & ./go/bin/localobjstore"]
     networks:
         mynetwork:
@@ -45,7 +45,7 @@ services:
       - "50003:50003"
 
   worker3:
-    image: ray-node
+    image: ray-node:driver
     command: ["/bin/sh", "-c", "./go/bin/localscheduler & ./go/bin/localobjstore"]
     networks:
         mynetwork:


### PR DESCRIPTION
Now we have different Docker images for different nodes. For example, for worker nodes we can specify `ray-node:driver`, which should include some basic necessities for a driver like `nano` or Python package installation (dill and babyray).

Also updated Makefile to reflect these changes.