### PR TITLE
Fig 8a and 9

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -55,7 +55,7 @@ ENV PROJECT_ROOT=/app
 FROM base as driver
 
 # install necessary Python packages to run anything
-RUN python3 -m pip install dill cloudpickle --break-system-packages
+RUN python3 -m pip install cloudpickle posix_ipc --break-system-packages
 RUN cd python && python3 -m pip install -e . --break-system-packages
 
 # install basic necessities to actually do driver stuff

--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,10 @@ py: proto
 	@echo "Modifying import statements for relative imports..."
 	# below line is now compatible with both MacOS (BSD) and GNU
 	sed -i'' -e 's/import rayclient_pb2 as rayclient__pb2/from . import rayclient_pb2 as rayclient__pb2/' python/babyray/rayclient_pb2_grpc.py
+	# need to copy these to pythonserver/, for worker.py
+	cp python/babyray/rayclient_pb2_grpc.py pythonserver
+	cp python/babyray/rayclient_pb2.py pythonserver
+    
 
 build: servers
 

--- a/config/app_config.yaml
+++ b/config/app_config.yaml
@@ -1,4 +1,6 @@
 num_worker_nodes: 5
+# simulating zero latency with some data throughput speed
+simulated_delay: 0.0
 node_ids:
   gcs: 0
   global_scheduler: 1

--- a/docker-compose.fig8a.yml
+++ b/docker-compose.fig8a.yml
@@ -2,7 +2,7 @@ version: '3'
 
 services:
   worker1:
-    command: ["/bin/sh", "-c", "./go/bin/worker & ./go/bin/localobjstore & ./go/bin/localscheduler & sleep 2 && python3 scripts/fig8a.py 1 & sleep infinity"]
+    command: ["/bin/sh", "-c", "python3 -u -m pythonserver.worker & ./go/bin/localobjstore & ./go/bin/localscheduler & sleep 2 && python3 -u scripts/fig8a.py & sleep infinity"]
     depends_on:
       - worker2
       - worker3

--- a/docker-compose.fig8a.yml
+++ b/docker-compose.fig8a.yml
@@ -2,8 +2,9 @@ version: '3'
 
 services:
   worker1:
-    command: ["/bin/sh", "-c", "python3 -u -m pythonserver.worker & ./go/bin/localobjstore & ./go/bin/localscheduler & sleep 2 && python3 -u scripts/fig8a.py & sleep infinity"]
+    command: ["/bin/sh", "-c", "python3 -u -m pythonserver.worker & ./go/bin/localobjstore & ./go/bin/localscheduler & sleep 5 && python3 -u scripts/fig8a.py & sleep infinity"]
     depends_on:
+      # - zookeeper
       - worker2
       - worker3
       - gcs

--- a/docker-compose.fig8a.yml
+++ b/docker-compose.fig8a.yml
@@ -1,0 +1,17 @@
+version: '3'
+
+services:
+  worker1:
+    command: ["/bin/sh", "-c", "./go/bin/worker & ./go/bin/localobjstore & ./go/bin/localscheduler & sleep 2 && python3 scripts/fig8a.py 1 & sleep infinity"]
+    depends_on:
+      - worker2
+      - worker3
+      - gcs
+      - global_scheduler
+
+#  worker2:
+#    command: ["/bin/sh", "-c", "./go/bin/localscheduler & ./go/bin/localobjstore & ./go/bin/worker"]
+#
+#  worker3:
+#    command: ["/bin/sh", "-c", "./go/bin/localscheduler & ./go/bin/localobjstore & ./go/bin/worker"]
+

--- a/docker-compose.fig9.yml
+++ b/docker-compose.fig9.yml
@@ -1,0 +1,11 @@
+version: '3'
+
+services:
+  worker1:
+    command: ["/bin/sh", "-c", "python3 -u -m pythonserver.worker & ./go/bin/localobjstore & ./go/bin/localscheduler & sleep 5 && python3 -u scripts/fig9.py & sleep infinity"]
+    depends_on:
+      # - zookeeper
+      - worker2
+      - worker3
+      - gcs
+      - global_scheduler

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -41,6 +41,7 @@ services:
                 - node2
     # depends_on:
     #   - zookeeper
+    shm_size: '4g'
     ports:
       - "50002:50002"
     environment:
@@ -55,6 +56,7 @@ services:
                 - node3
     # depends_on:
     #   - zookeeper
+    shm_size: '4g'
     ports:
       - "50003:50003"
     environment:
@@ -70,6 +72,7 @@ services:
                 - node4
     # depends_on:
     #   - zookeeper
+    shm_size: '4g'
     ports:
       - "50004:50004"
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,13 @@
 version: '3'
 
 services:
+  # zookeeper:
+  #   image: zookeeper:3.6.3
+  #   ports:
+  #     - "2181:2181"
+  #   networks:
+  #     mynetwork:
+
   gcs:
     image: ray-node:base
     command: ["/bin/sh", "-c", "./go/bin/gcsfunctable & ./go/bin/gcsobjtable"]
@@ -8,6 +15,8 @@ services:
         mynetwork:
             aliases:
                 - node0
+    # depends_on:
+    #   - zookeeper
     ports:
       - "50000:50000"
 
@@ -30,6 +39,8 @@ services:
         mynetwork:
             aliases:
                 - node2
+    # depends_on:
+    #   - zookeeper
     ports:
       - "50002:50002"
     environment:
@@ -42,6 +53,8 @@ services:
         mynetwork:
             aliases:
                 - node3
+    # depends_on:
+    #   - zookeeper
     ports:
       - "50003:50003"
     environment:
@@ -55,6 +68,8 @@ services:
         mynetwork:
             aliases:
                 - node4
+    # depends_on:
+    #   - zookeeper
     ports:
       - "50004:50004"
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,7 +25,7 @@ services:
 
   worker1:
     image: ray-node:driver
-    command: ["/bin/sh", "-c", "./go/bin/worker & ./go/bin/localobjstore & ./go/bin/localscheduler & sleep infinity"]
+    command: ["/bin/sh", "-c", "python3 -u -m pythonserver.worker & ./go/bin/localobjstore & ./go/bin/localscheduler & sleep infinity"]
     networks:
         mynetwork:
             aliases:
@@ -37,7 +37,7 @@ services:
 
   worker2:
     image: ray-node:driver
-    command: ["/bin/sh", "-c", "./go/bin/worker & ./go/bin/localobjstore & ./go/bin/localscheduler & sleep infinity"]
+    command: ["/bin/sh", "-c", "python3 -u -m pythonserver.worker & ./go/bin/localobjstore & ./go/bin/localscheduler & sleep infinity"]
     networks:
         mynetwork:
             aliases:
@@ -49,7 +49,7 @@ services:
 
   worker3:
     image: ray-node:driver
-    command: ["/bin/sh", "-c", "./go/bin/worker & ./go/bin/localobjstore & ./go/bin/localscheduler & sleep infinity"]
+    command: ["/bin/sh", "-c", "python3 -u -m pythonserver.worker & ./go/bin/localobjstore & ./go/bin/localscheduler & sleep infinity"]
     #command: ["/bin/sh", "-c", "./go/bin/localscheduler & ./go/bin/localobjstore & ./go/bin/worker"]
     networks:
         mynetwork:

--- a/go/cmd/gcsfunctable/main.go
+++ b/go/cmd/gcsfunctable/main.go
@@ -12,6 +12,7 @@ import (
     "google.golang.org/grpc"
     pb "github.com/rodrigo-castellon/babyray/pkg"
     "github.com/rodrigo-castellon/babyray/config"
+    "github.com/rodrigo-castellon/babyray/util"
 
     "google.golang.org/grpc/status"
     "google.golang.org/grpc/codes"
@@ -26,7 +27,7 @@ func main() {
         log.Fatalf("failed to listen: %v", err)
     }
     _ = lis;
-    s := grpc.NewServer()
+    s := grpc.NewServer(util.GetServerOptions()...)
     pb.RegisterGCSFuncServer(s, NewGCSFuncServer())
     log.Printf("server listening at %v", lis.Addr())
     if err := s.Serve(lis); err != nil {

--- a/go/cmd/gcsobjtable/main.go
+++ b/go/cmd/gcsobjtable/main.go
@@ -195,11 +195,11 @@ func (s *GCSObjServer) RequestLocation(ctx context.Context, req *pb.RequestLocat
 
 func (s *GCSObjServer) GetObjectLocations(ctx context.Context, req *pb.ObjectLocationsRequest) (*pb.ObjectLocationsResponse, error) {
 	locations := make(map[uint64]*pb.LocationByteTuple)
-	log.Printf("DEEP PRINT!")
-	log.Printf("length = %v", len(s.objectLocations))
-	for k, v := range s.objectLocations {
-		log.Printf("s.objectLocations[%v] = %v", k, v)
-	}
+	// log.Printf("DEEP PRINT!")
+	// log.Printf("length = %v", len(s.objectLocations))
+	// for k, v := range s.objectLocations {
+	// 	log.Printf("s.objectLocations[%v] = %v", k, v)
+	// }
 
 	for _, u := range req.Args {
 		if _,ok := s.objectLocations[uint64(u)]; ok {

--- a/go/cmd/globalscheduler/main.go
+++ b/go/cmd/globalscheduler/main.go
@@ -58,7 +58,7 @@ type server struct {
 
 
 func (s *server) Heartbeat(ctx context.Context, req *pb.HeartbeatRequest ) (*pb.StatusResponse, error) {
-    // log.Printf("heartbeat from %v", req.NodeId)
+    log.Printf("heartbeat from %v", req.NodeId)
     mu.Lock()
     numQueuedTasks := req.QueuedTasks
     if (req.RunningTasks == 10) {
@@ -117,7 +117,7 @@ func getBestWorker(ctx context.Context, s *server, localityFlag bool, uids []uin
     var foundBest bool
 
     minTime = math.MaxFloat32
-    if localityFlag {
+    if (localityFlag && len(uids) > 0) {
         log.Printf("LOCALITY FLAG IS ON!")
         log.Printf("ASKING THE GCS FOR THESE OBJECTS: %v", uids)
         locationsResp, err := s.gcsClient.GetObjectLocations(ctx, &pb.ObjectLocationsRequest{Args: uids})
@@ -159,6 +159,7 @@ func getBestWorker(ctx context.Context, s *server, localityFlag bool, uids []uin
             }
         }
     } else {
+        log.Printf("doing the statuses rn")
         // TODO: make iteration order random for maximum fairness
         mu.RLock()
         for id, heartbeat := range s.status {

--- a/go/cmd/globalscheduler/main.go
+++ b/go/cmd/globalscheduler/main.go
@@ -8,18 +8,22 @@ import (
     // "math/rand"
     "math"
    // "bytes"
+   "time"
    "os"
    "sync"
     "fmt"
     "google.golang.org/grpc"
     pb "github.com/rodrigo-castellon/babyray/pkg"
     "github.com/rodrigo-castellon/babyray/config"
+    "github.com/rodrigo-castellon/babyray/customlog"
+    "github.com/rodrigo-castellon/babyray/util"
 )
 var cfg *config.Config
 
 var mu sync.RWMutex
 
 func main() {
+    customlog.Init()
     cfg = config.LoadConfig() // Load configuration
     address := ":" + strconv.Itoa(cfg.Ports.GlobalScheduler) // Prepare the network address
 
@@ -28,9 +32,9 @@ func main() {
         log.Fatalf("failed to listen: %v", err)
     }
     _ = lis;
-    s := grpc.NewServer()
+    s := grpc.NewServer(util.GetServerOptions()...)
     gcsAddress := fmt.Sprintf("%s%d:%d", cfg.DNS.NodePrefix, cfg.NodeIDs.GCS, cfg.Ports.GCSObjectTable)
-	conn, _ := grpc.Dial(gcsAddress, grpc.WithInsecure())
+	conn, _ := grpc.Dial(gcsAddress, util.GetDialOptions()...)
     pb.RegisterGlobalSchedulerServer(s, &server{gcsClient: pb.NewGCSObjClient(conn), status: make(map[uint64]HeartbeatEntry)})
     defer conn.Close()
     log.Printf("server listening at %v", lis.Addr())
@@ -56,7 +60,12 @@ type server struct {
 func (s *server) Heartbeat(ctx context.Context, req *pb.HeartbeatRequest ) (*pb.StatusResponse, error) {
     // log.Printf("heartbeat from %v", req.NodeId)
     mu.Lock()
-    s.status[req.NodeId] = HeartbeatEntry{numRunningTasks: req.RunningTasks, numQueuedTasks: req.QueuedTasks, avgRunningTime: req.AvgRunningTime, avgBandwidth: req.AvgBandwidth}
+    numQueuedTasks := req.QueuedTasks
+    if (req.RunningTasks == 10) {
+        numQueuedTasks = numQueuedTasks + 1 // also need to wait for something currently running to finish
+    }
+
+    s.status[req.NodeId] = HeartbeatEntry{numRunningTasks: req.RunningTasks, numQueuedTasks: numQueuedTasks, avgRunningTime: req.AvgRunningTime, avgBandwidth: req.AvgBandwidth}
     mu.Unlock()
     return &pb.StatusResponse{Success: true}, nil
 }
@@ -67,11 +76,18 @@ func (s *server) Schedule(ctx context.Context , req *pb.GlobalScheduleRequest ) 
         localityFlag = true
     }
 
+    log.Printf("THE REQ UIDS ARE = %v", req.Uids)
+
     // gives us back the node id of the worker
-    node_id := getBestWorker(ctx, s, localityFlag, req.Uids)
+    node_id := req.NodeId
+    if (req.NodeId == 0) {
+        node_id = getBestWorker(ctx, s, localityFlag, req.Uids)
+    }
+
+    log.Printf("best worker was node_id = %v", node_id)
     workerAddress := fmt.Sprintf("%s%d:%d", cfg.DNS.NodePrefix, node_id, cfg.Ports.LocalWorkerStart)
 
-    conn, err := grpc.Dial(workerAddress, grpc.WithInsecure())
+    conn, err := grpc.Dial(workerAddress, util.GetDialOptions()...)
     if err != nil {
         log.Printf("failed to connect to %s: %v", workerAddress, err)
         return nil, err
@@ -80,7 +96,14 @@ func (s *server) Schedule(ctx context.Context , req *pb.GlobalScheduleRequest ) 
 
     workerClient := pb.NewWorkerClient(conn)
 
-    output_result, err := workerClient.Run(ctx, &pb.RunRequest{Uid: req.Uid, Name: req.Name, Args: req.Args, Kwargs: req.Kwargs})
+    log.Printf("gonna call Run() now")
+
+    // Example of creating a context with a timeout
+    // For some reason this custom context is necessary... ¯\_(ツ)_/¯
+    customCtx, cancel := context.WithTimeout(context.Background(), time.Hour)
+    defer cancel()
+
+    output_result, err := workerClient.Run(customCtx, &pb.RunRequest{Uid: req.Uid, Name: req.Name, Args: req.Args, Kwargs: req.Kwargs})
     if err != nil || !output_result.Success {
         log.Fatalf(fmt.Sprintf("global scheduler failed to contact node %d. Err: %v", node_id, err))
     }
@@ -95,6 +118,8 @@ func getBestWorker(ctx context.Context, s *server, localityFlag bool, uids []uin
 
     minTime = math.MaxFloat32
     if localityFlag {
+        log.Printf("LOCALITY FLAG IS ON!")
+        log.Printf("ASKING THE GCS FOR THESE OBJECTS: %v", uids)
         locationsResp, err := s.gcsClient.GetObjectLocations(ctx, &pb.ObjectLocationsRequest{Args: uids})
         if err != nil {
             log.Fatalf("Failed to ask gcs for object locations: %v", err)
@@ -111,6 +136,7 @@ func getBestWorker(ctx context.Context, s *server, localityFlag bool, uids []uin
         total = 0
         for _, val := range locationsResp.Locations {
             locs := val.Locations
+            log.Printf("the locations resp val = %v", val)
             for _, loc := range locs {
                 locationToBytes[uint64(loc)] += val.Bytes
                 total += val.Bytes
@@ -120,8 +146,10 @@ func getBestWorker(ctx context.Context, s *server, localityFlag bool, uids []uin
         for loc, bytes := range locationToBytes {
             mu.RLock()
             queueingTime := float32(s.status[loc].numQueuedTasks) * s.status[loc].avgRunningTime
-            transferTime := float32(total - bytes) * s.status[loc].avgBandwidth
+            transferTime := float32(total - bytes) / s.status[loc].avgBandwidth
             mu.RUnlock()
+
+            log.Printf("worker = %v; queueing and transfer = %v, %v", loc, queueingTime, transferTime)
 
             waitingTime := queueingTime + transferTime
             if waitingTime < minTime {
@@ -134,6 +162,7 @@ func getBestWorker(ctx context.Context, s *server, localityFlag bool, uids []uin
         // TODO: make iteration order random for maximum fairness
         mu.RLock()
         for id, heartbeat := range s.status {
+            log.Printf("worker = %v; queued time = %v", id, float32(heartbeat.numQueuedTasks) * heartbeat.avgRunningTime)
             if float32(heartbeat.numQueuedTasks) * heartbeat.avgRunningTime < minTime {
                 minId = id
                 minTime = float32(heartbeat.numQueuedTasks) * heartbeat.avgRunningTime

--- a/go/cmd/localobjstore/main.go
+++ b/go/cmd/localobjstore/main.go
@@ -11,6 +11,8 @@ import (
 	"os"
 	// "time"
 	"sync"
+	"syscall"
+	// "golang.org/x/sys/unix"
 
 	"github.com/rodrigo-castellon/babyray/config"
 	"github.com/rodrigo-castellon/babyray/customlog"
@@ -20,6 +22,66 @@ import (
 )
 
 const DEFAULT_AVG_BANDWIDTH = 0.1 // to start with
+
+func createSharedMemory(name string, size int) ([]byte, int, error) {
+    // Create a shared memory segment
+	LocalLog("WERE GONNA CREATE A /DEV FILE WITH THIS NAME: %s", "/dev/shm/"+name)
+    shmFd, err := syscall.Open("/dev/shm/"+name, syscall.O_CREAT|syscall.O_RDWR, 0666)
+    if err != nil {
+        return nil, -1, err
+    }
+
+    // Set the size of the shared memory object
+    if err := syscall.Ftruncate(shmFd, int64(size)); err != nil {
+        return nil, -1, err
+    }
+
+    // Map the shared memory object into the process's address space
+    shmAddr, err := syscall.Mmap(shmFd, 0, size, syscall.PROT_READ|syscall.PROT_WRITE, syscall.MAP_SHARED)
+    if err != nil {
+        return nil, -1, err
+    }
+
+	LocalLog("/DEV FILE CREATED!")
+
+    return shmAddr, shmFd, nil
+}
+
+// Function to open and read from a shared memory segment
+func readSharedMemory(name string, size int) ([]byte, error) {
+	LocalLog("WERE GONNA READ A /DEV FILE WITH THIS NAME: %s", "/dev/shm/"+name)
+	// Open the shared memory object
+	shmFd, err := syscall.Open("/dev/shm/"+name, syscall.O_RDWR, 0666)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open shared memory: %v", err)
+	}
+
+	// Map the shared memory object into the process's address space
+	shmAddr, err := syscall.Mmap(shmFd, 0, size, syscall.PROT_READ|syscall.PROT_WRITE, syscall.MAP_SHARED)
+	if err != nil {
+		return nil, fmt.Errorf("failed to mmap shared memory: %v", err)
+	}
+
+	// Close the file descriptor as it is no longer needed
+	if err := syscall.Close(shmFd); err != nil {
+		return nil, fmt.Errorf("failed to close shared memory file descriptor: %v", err)
+	}
+
+	return shmAddr, nil
+}
+
+func deleteSharedMemory(name string, shmFd int) error {
+    // Close the file descriptor
+    if err := syscall.Close(shmFd); err != nil {
+        return err
+    }
+    // Unlink the shared memory object
+    if err := syscall.Unlink("/dev/shm/" + name); err != nil {
+        return err
+    }
+    return nil
+}
+
 
 // LocalLog formats the message and logs it with a specific prefix
 func LocalLog(format string, v ...interface{}) {
@@ -56,7 +118,7 @@ func startServer(port string) (*grpc.Server, error) {
     gcsAddress := fmt.Sprintf("%s%d:%d", cfg.DNS.NodePrefix, cfg.NodeIDs.GCS, cfg.Ports.GCSObjectTable)
 	conn, _ := grpc.Dial(gcsAddress, util.GetDialOptions()...)
 	nodeId, _ := strconv.Atoi(os.Getenv("NODE_ID"))
-	pb.RegisterLocalObjStoreServer(s, &server{localObjectStore: make(map[uint64][]byte), localObjectChannels: make(map[uint64]chan *pb.LocationFoundCallback), gcsObjClient: pb.NewGCSObjClient(conn), localNodeID: uint64(nodeId), avgBandwidth: DEFAULT_AVG_BANDWIDTH})
+	pb.RegisterLocalObjStoreServer(s, &server{localObjectStore: make(map[uint64][]byte), objectSizes: make(map[uint64]uint64), localObjectChannels: make(map[uint64]chan *pb.LocationFoundCallback), gcsObjClient: pb.NewGCSObjClient(conn), localNodeID: uint64(nodeId), avgBandwidth: DEFAULT_AVG_BANDWIDTH})
 
 
 	LocalLog("lobs server listening at %v", lis.Addr())
@@ -74,6 +136,8 @@ func startServer(port string) (*grpc.Server, error) {
 type server struct {
 	pb.UnimplementedLocalObjStoreServer
 	localObjectStore    map[uint64][]byte
+	// set storing which uid's are stored in POSIX shared memory -> sizes
+	objectSizes			map[uint64]uint64
 	localObjectChannels map[uint64]chan *pb.LocationFoundCallback
 	gcsObjClient        pb.GCSObjClient
 	localNodeID         uint64
@@ -81,20 +145,45 @@ type server struct {
 }
 
 func (s *server) Store(ctx context.Context, req *pb.StoreRequest) (*pb.StatusResponse, error) {
+	size := uint64(len(req.ObjectBytes))
+
+	// store to shared memory (internally sync'd)
+	shmSlice, _, err := createSharedMemory(strconv.FormatUint(req.Uid, 10), int(size))
+	if err != nil {
+		return nil, err
+	}
+
+	LocalLog("NOW ATTEMPTING TO COPY OBJECT BYTES INTO SHARED MEMORY SLICE")
+
+	copy(shmSlice, req.ObjectBytes)
+
+
+	LocalLog("COPIED!")
+
 	mu.Lock()
-	s.localObjectStore[req.Uid] = req.ObjectBytes
+	// s.localObjectStore[req.Uid] = req.ObjectBytes
+	// store this in our set
+	s.objectSizes[req.Uid] = size;
 	mu.Unlock()
 
-	s.gcsObjClient.NotifyOwns(ctx, &pb.NotifyOwnsRequest{Uid: req.Uid, NodeId: s.localNodeID, ObjectSize: uint64(len(req.ObjectBytes))})
+	LocalLog("STORED!!!")
+
+	s.gcsObjClient.NotifyOwns(ctx, &pb.NotifyOwnsRequest{Uid: req.Uid, NodeId: s.localNodeID, ObjectSize: size})
 	return &pb.StatusResponse{Success: true}, nil
 }
 
 func (s *server) Get(ctx context.Context, req *pb.GetRequest) (*pb.GetResponse, error) {
 	mu.RLock()
-	if val, ok := s.localObjectStore[req.Uid]; ok {
+	if val, ok := s.objectSizes[req.Uid]; ok {
 		mu.RUnlock()
-		return &pb.GetResponse{Uid: req.Uid, ObjectBytes: val, Local: true}, nil
+		LocalLog("ITS IN OBJECT SIZES!")
+		return &pb.GetResponse{Uid: req.Uid, ObjectBytes: []byte{}, Local: true, Size: val}, nil
 	}
+	LocalLog("THE UID WAS NOT IN OBJECT SIZES: %v", req.Uid)
+	// if val, ok := s.localObjectStore[req.Uid]; ok {
+	// 	mu.RUnlock()
+	// 	return &pb.GetResponse{Uid: req.Uid, ObjectBytes: val, Local: true}, nil
+	// }
 	mu.RUnlock()
 
 	// LocalLog("IN GET() RN!")
@@ -143,20 +232,31 @@ func (s *server) Get(ctx context.Context, req *pb.GetRequest) (*pb.GetResponse, 
 	// s.avgBandwidth = EMA_PARAM * s.avgBandwidth + (1 - EMA_PARAM) * bandwidth 
 
 	if x == nil || err != nil {
-		return &pb.GetResponse{Uid: req.Uid}, errors.New(fmt.Sprintf("failed to copy from other LOS @:%s ", otherLocalAddress))
-	}
-
-	if (resp.Port == 0 && req.Cache) {
-			s.gcsObjClient.NotifyOwns(ctx, &pb.NotifyOwnsRequest{Uid: resp.Uid, NodeId: s.localNodeID})
+		return &pb.GetResponse{Uid: req.Uid}, errors.New(fmt.Sprintf("failed to copy from other LOS @:%s. err was: %v ", otherLocalAddress, err))
 	}
 
 	// val := <-s.localObjectChannels[req.Uid]
 	if (req.Cache) {
-		mu.Lock()
-		s.localObjectStore[req.Uid] = x.ObjectBytes
-		mu.Unlock()
-	}
+		size := uint64(len(x.ObjectBytes))
 
+		// store to shared memory (internally sync'd)
+		shmSlice, _, err := createSharedMemory(strconv.FormatUint(req.Uid, 10), int(size))
+		if err != nil {
+			return nil, err
+		}
+
+		copy(shmSlice, x.ObjectBytes)
+
+		mu.Lock()
+		s.objectSizes[req.Uid] = size;
+
+		// s.localObjectStore[req.Uid] = x.ObjectBytes
+		mu.Unlock()
+		if (resp.Port == 0) {
+			s.gcsObjClient.NotifyOwns(ctx, &pb.NotifyOwnsRequest{Uid: resp.Uid, NodeId: s.localNodeID})
+		}
+		return &pb.GetResponse{Uid: req.Uid, ObjectBytes: x.ObjectBytes, Local: false, Size: size}, nil
+	}
 	return &pb.GetResponse{Uid: req.Uid, ObjectBytes: x.ObjectBytes, Local: false}, nil
 }
 
@@ -170,13 +270,31 @@ func (s *server) LocationFound(ctx context.Context, resp *pb.LocationFoundCallba
 }
 
 func (s *server) Copy(ctx context.Context, req *pb.CopyRequest) (*pb.CopyResponse, error) {
+	// name := fmt.Sprintf("shm-%d", req.Uid)
+	// size := 4096 // This should be the size of your shared memory segment
 	mu.RLock()
-	data, ok := s.localObjectStore[req.Uid]
+	size, ok := s.objectSizes[req.Uid]
 	mu.RUnlock()
 	if !ok {
 		return &pb.CopyResponse{Uid: req.Uid, ObjectBytes: nil}, errors.New("object was not in LOS")
 	}
+
+	data, err := readSharedMemory(strconv.FormatUint(req.Uid, 10), int(size))
+	if err != nil {
+		LocalLog("got err from read: %v", err)
+		return nil, err
+	}
+
 	return &pb.CopyResponse{Uid: req.Uid, ObjectBytes: data}, nil
+
+	// mu.RLock()
+
+	// data, ok := s.localObjectStore[req.Uid]
+	// mu.RUnlock()
+	// if !ok {
+	// 	return &pb.CopyResponse{Uid: req.Uid, ObjectBytes: nil}, errors.New("object was not in LOS")
+	// }
+	// return &pb.CopyResponse{Uid: req.Uid, ObjectBytes: data}, nil
 }
 
 func(s *server) AvgBandwidth(ctx context.Context, req *pb.StatusResponse) (*pb.BandwidthResponse, error) {

--- a/go/cmd/localscheduler/main.go
+++ b/go/cmd/localscheduler/main.go
@@ -117,7 +117,7 @@ func (s *server) Schedule(ctx context.Context, req *pb.ScheduleRequest) (*pb.Sch
 		LocalLog("contacting global scheduler")
 		go func() {
 			LocalLog("THE REQ UIDS AT LOCAL SCHEDULER ARE %v", req.Uids)
-            _, err := s.globalSchedulerClient.Schedule(s.globalCtx, &pb.GlobalScheduleRequest{Uid: uid, Name: req.Name, Args: req.Args, Kwargs: req.Kwargs, Uids: req.Uids})
+            _, err := s.globalSchedulerClient.Schedule(s.globalCtx, &pb.GlobalScheduleRequest{Uid: uid, Name: req.Name, Args: req.Args, Kwargs: req.Kwargs, Uids: req.Uids, LocalityFlag: req.LocalityFlag})
             if err != nil {
                 LocalLog("cannot contact global scheduler")
             } else {
@@ -202,7 +202,7 @@ func SendHeartbeats(ctx context.Context, globalSchedulerClient pb.GlobalSchedule
 		// 	heartbeatRequest.AvgBandwidth,
 		// 	heartbeatRequest.NodeId)
 
-		LocalLog("SENDING GLOBAL SCHEDULER A HEARTBEAT!!!")
+		// LocalLog("SENDING GLOBAL SCHEDULER A HEARTBEAT!!!")
 		globalSchedulerClient.Heartbeat(ctx, heartbeatRequest)
 	    time.Sleep(HEARTBEAT_WAIT)
 	}

--- a/go/cmd/localscheduler/main.go
+++ b/go/cmd/localscheduler/main.go
@@ -11,6 +11,8 @@ import (
 	"time"
 
 	"github.com/rodrigo-castellon/babyray/config"
+	"github.com/rodrigo-castellon/babyray/customlog"
+	"github.com/rodrigo-castellon/babyray/util"
 	pb "github.com/rodrigo-castellon/babyray/pkg"
 	"google.golang.org/grpc"
 )
@@ -32,6 +34,7 @@ func LocalLog(format string, v ...interface{}) {
 }
 
 func main() {
+	customlog.Init()
 	cfg = config.GetConfig()                                // Load configuration
 	address := ":" + strconv.Itoa(cfg.Ports.LocalScheduler) // Prepare the network address
 	lis, err := net.Listen("tcp", address)
@@ -39,16 +42,16 @@ func main() {
 		log.Fatalf("failed to listen: %v", err)
 	}
 	_ = lis
-	s := grpc.NewServer()
+	s := grpc.NewServer(util.GetServerOptions()...)
 
 	// set up worker connection early
 	workerAddress := fmt.Sprintf("localhost:%d", cfg.Ports.LocalWorkerStart)
-	workerConn, _ := grpc.Dial(workerAddress, grpc.WithInsecure())
+	workerConn, _ := grpc.Dial(workerAddress, util.GetDialOptions()...)
 
 	workerClient := pb.NewWorkerClient(workerConn)
 
 	globalSchedulerAddress := fmt.Sprintf("%s%d:%d", cfg.DNS.NodePrefix, cfg.NodeIDs.GlobalScheduler, cfg.Ports.GlobalScheduler)
-	conn, _ := grpc.Dial(globalSchedulerAddress, grpc.WithInsecure())
+	conn, _ := grpc.Dial(globalSchedulerAddress, util.GetDialOptions()...)
 	globalSchedulerClient := pb.NewGlobalSchedulerClient(conn)
 	nodeId, _ := strconv.Atoi(os.Getenv("NODE_ID"))
 
@@ -75,9 +78,25 @@ type server struct {
 // Implement your service methods here.
 
 func (s *server) Schedule(ctx context.Context, req *pb.ScheduleRequest) (*pb.ScheduleResponse, error) {
+
 	var worker_id int
 	worker_id, _ = strconv.Atoi(os.Getenv("NODE_ID"))
     uid := rand.Uint64()
+
+	// custom behavior if the client itself specifies where we should send this
+	// computation
+	if (req.NodeId != 0) {
+		LocalLog("Doing something special with req.NodeId = %v", req.NodeId)
+		go func() {
+            _, err := s.globalSchedulerClient.Schedule(s.globalCtx, &pb.GlobalScheduleRequest{Uid: uid, Name: req.Name, Args: req.Args, Kwargs: req.Kwargs, Uids: req.Uids, NodeId: req.NodeId})
+            if err != nil {
+                LocalLog("cannot contact global scheduler")
+            } else {
+				// LocalLog("Just ran it on global!")
+			}
+        }()
+		return &pb.ScheduleResponse{Uid: uid}, nil
+	}
 
 	scheduleLocally, _ := s.workerClient.WorkerStatus(ctx, &pb.StatusResponse{})
 
@@ -95,6 +114,7 @@ func (s *server) Schedule(ctx context.Context, req *pb.ScheduleRequest) (*pb.Sch
 	} else {
 		// LocalLog("contacting global scheduler")
 		go func() {
+			LocalLog("THE REQ UIDS AT LOCAL SCHEDULER ARE %v", req.Uids)
             _, err := s.globalSchedulerClient.Schedule(s.globalCtx, &pb.GlobalScheduleRequest{Uid: uid, Name: req.Name, Args: req.Args, Kwargs: req.Kwargs, Uids: req.Uids})
             if err != nil {
                 LocalLog("cannot contact global scheduler")
@@ -110,14 +130,14 @@ func (s *server) Schedule(ctx context.Context, req *pb.ScheduleRequest) (*pb.Sch
 
 func SendHeartbeats(ctx context.Context, globalSchedulerClient pb.GlobalSchedulerClient, nodeId uint64 ) {
 	workerAddress := fmt.Sprintf("localhost:%d", cfg.Ports.LocalWorkerStart)
-	workerConn, err := grpc.Dial(workerAddress, grpc.WithInsecure())
+	workerConn, err := grpc.Dial(workerAddress, util.GetDialOptions()...)
 	if err != nil {
 		log.Fatalf("failed to connect to %s: %v", workerAddress, err)
 	}
     defer workerConn.Close()
 
 	lobsAddress := fmt.Sprintf("localhost:%d", cfg.Ports.LocalObjectStore)
-	lobsConn, err := grpc.Dial(lobsAddress, grpc.WithInsecure())
+	lobsConn, err := grpc.Dial(lobsAddress, util.GetDialOptions()...)
 	if err != nil {
 		log.Fatalf("failed to connect to %s: %v", lobsAddress, err)
 		

--- a/go/config/config.go
+++ b/go/config/config.go
@@ -13,6 +13,7 @@ var cfg *Config
 type Config struct {
     NumWorkerNodes int `yaml:"num_worker_nodes"`
     ClusterSize    int `yaml:"cluster_size"`
+    SimulatedDelay float32 `yaml:"simulated_delay"`
     NodeIDs        struct {
         GCS             int `yaml:"gcs"`
         GlobalScheduler int `yaml:"global_scheduler"`

--- a/go/customlog/customlog.go
+++ b/go/customlog/customlog.go
@@ -1,0 +1,23 @@
+// customlog.go
+package customlog
+
+import (
+	"log"
+	"os"
+	"time"
+)
+
+type logWriter struct {
+	writer *os.File
+}
+
+func (lw *logWriter) Write(data []byte) (int, error) {
+	timestamp := time.Now().Format("2006/01/02 15:04:05.000")
+	return lw.writer.Write(append([]byte(timestamp+" "), data...))
+}
+
+// Init initializes the custom logger with millisecond precision timestamps.
+func Init() {
+	log.SetFlags(0) // Disable default flags
+	log.SetOutput(&logWriter{os.Stdout})
+}

--- a/go/go.mod
+++ b/go/go.mod
@@ -9,8 +9,6 @@ require (
 )
 
 require (
-	github.com/golang/protobuf v1.5.4 // indirect
-	github.com/stretchr/testify v1.9.0 // indirect
 	golang.org/x/net v0.21.0 // indirect
 	golang.org/x/sys v0.17.0 // indirect
 	golang.org/x/text v0.14.0 // indirect

--- a/go/go.sum
+++ b/go/go.sum
@@ -1,9 +1,5 @@
-github.com/golang/protobuf v1.5.4 h1:i7eJL8qZTpSEXOPTxNKhASYpMn+8e5Q6AdndVa1dWek=
-github.com/golang/protobuf v1.5.4/go.mod h1:lnTiLA8Wa4RWRcIUkrtSVa5nRhsEGBg48fD6rSs7xps=
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
-github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
-github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 golang.org/x/net v0.21.0 h1:AQyQV4dYCvJ7vGmJyKki9+PBdyvhkSd8EIx/qb0AYv4=
 golang.org/x/net v0.21.0/go.mod h1:bIjVDfnllIU7BJ2DNgfnXvpSvtn8VRwhlsaeUTyUS44=
 golang.org/x/sys v0.17.0 h1:25cE3gD+tdBA7lp7QfhuV+rJiE9YXTcS3VG1SqssI/Y=

--- a/go/util/util.go
+++ b/go/util/util.go
@@ -2,11 +2,40 @@ package util
 
 import (
 	"context"
+	"time"
 
+	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
+	"google.golang.org/grpc/keepalive"
 )
+
+// GetDialOptions returns the gRPC dial options with max message size set.
+func GetDialOptions() []grpc.DialOption {
+	// Set the max size options
+	return []grpc.DialOption{
+		grpc.WithInsecure(),
+		grpc.WithDefaultCallOptions(
+			grpc.MaxCallRecvMsgSize(1024 * 1024 * 1024), // 1GB
+			grpc.MaxCallSendMsgSize(1024 * 1024 * 1024), // 1GB
+		),
+	}
+}
+
+// GetServerOptions returns the gRPC server options with max message size set.
+func GetServerOptions() []grpc.ServerOption {
+	const MAX_MSG_SIZE = 200 * 1024 * 1024 // 200MB
+
+	return []grpc.ServerOption{
+		grpc.MaxRecvMsgSize(MAX_MSG_SIZE),
+		grpc.MaxSendMsgSize(MAX_MSG_SIZE),
+		grpc.KeepaliveParams(keepalive.ServerParameters{
+			MaxConnectionIdle: 5 * time.Minute,
+		}),
+	}
+}
+
 
 // DEPRECATED -- DO NOT USE
 func ExtractAddressFromCtx(ctx context.Context) (string, error) {

--- a/go/util/util.go
+++ b/go/util/util.go
@@ -25,7 +25,7 @@ func GetDialOptions() []grpc.DialOption {
 
 // GetServerOptions returns the gRPC server options with max message size set.
 func GetServerOptions() []grpc.ServerOption {
-	const MAX_MSG_SIZE = 200 * 1024 * 1024 // 200MB
+	const MAX_MSG_SIZE = 1024 * 1024 * 1024 // 1GB
 
 	return []grpc.ServerOption{
 		grpc.MaxRecvMsgSize(MAX_MSG_SIZE),

--- a/proto/rayclient.proto
+++ b/proto/rayclient.proto
@@ -33,6 +33,7 @@ message GlobalScheduleRequest {
   // optional but in case the client wants to specify a node ID
   // to send a computation to
   uint64 nodeId = 6;
+  bool localityFlag = 7;
 }
 
 message HeartbeatRequest {
@@ -59,6 +60,7 @@ message ScheduleRequest {
   // optional but in case the client wants to specify a node ID
   // to send a computation to
   uint64 nodeId = 5;
+  bool localityFlag = 6;
 }
 
 // returns a Future, which is just the UID for

--- a/proto/rayclient.proto
+++ b/proto/rayclient.proto
@@ -29,7 +29,10 @@ message GlobalScheduleRequest {
   uint64 name = 2;
   bytes args = 3;
   bytes kwargs = 4;
-  repeated uint64 uids = 5; 
+  repeated uint64 uids = 5;
+  // optional but in case the client wants to specify a node ID
+  // to send a computation to
+  uint64 nodeId = 6;
 }
 
 message HeartbeatRequest {
@@ -52,7 +55,10 @@ message ScheduleRequest {
   uint64 name = 1;
   bytes args = 2;
   bytes kwargs = 3;
-  repeated uint64 uids = 4; 
+  repeated uint64 uids = 4;
+  // optional but in case the client wants to specify a node ID
+  // to send a computation to
+  uint64 nodeId = 5;
 }
 
 // returns a Future, which is just the UID for
@@ -78,7 +84,10 @@ message StoreRequest {
 
 message GetRequest {
   uint64 uid = 1;
-  bool testing = 2; 
+  bool testing = 2;
+  // normally is true, but is false whenever we want to just block
+  // for a task to complete
+  bool copy = 3;
 }
 
 message GetResponse {

--- a/proto/rayclient.proto
+++ b/proto/rayclient.proto
@@ -99,7 +99,8 @@ message GetRequest {
 message GetResponse {
   uint64 uid = 1; 
   bytes objectBytes = 2;
-  bool local = 3; 
+  bool local = 3;
+  uint64 size = 4;
 }
 
 message BandwidthResponse {

--- a/proto/rayclient.proto
+++ b/proto/rayclient.proto
@@ -90,6 +90,10 @@ message GetRequest {
   // normally is true, but is false whenever we want to just block
   // for a task to complete
   bool copy = 3;
+  // normally is true, but is false whenever we want to copy the
+  // object over but not cache it (so we can keep measuring the copy
+  // speed)
+  bool cache = 4;
 }
 
 message GetResponse {

--- a/python/babyray/__init__.py
+++ b/python/babyray/__init__.py
@@ -78,8 +78,12 @@ class RemoteFunction:
         self.func = func
         self.name = None
         self.node_id = None
+        self.locality_flag = True
 
-    """These two methods exist purely for experimental reasons."""
+    """These three methods exist purely for experimental reasons."""
+
+    def set_locality_flag(self, locality_flag):
+        self.locality_flag = locality_flag
 
     def set_node(self, node_id):
         # set the node ID to run this remote function on
@@ -103,6 +107,7 @@ class RemoteFunction:
                     kwargs=pickle.dumps(kwargs),
                     uids=arg_uids,
                     nodeId=self.node_id,
+                    localityFlag=self.locality_flag,
                 )
             ).uid
             return Future(uid)

--- a/pythonserver/constants.py
+++ b/pythonserver/constants.py
@@ -1,0 +1,36 @@
+# some constants, like the node ID's for the GCS, scheduler, and worker nodes
+
+NUM_WORKER_NODES = 5  # includes ourself
+CLUSTER_SIZE = NUM_WORKER_NODES + 2  # + GCS + global scheduler
+
+# we reserve the following node id's:
+# 0: GCS
+# 1: global scheduler
+# 2: ourself (driver/worker node)
+# the rest of the node id's >2 are worker nodes
+
+
+GCS_NODE_ID = 0
+GLOBAL_SCHEDULER_NODE_ID = 1
+OURSELF_NODE_ID = 2
+
+# we use DNS to assign each container a separate name, named
+# "nodeX" where "X" is the integer node ID
+
+# furthermore, we assign ports to correspond to services for worker nodes:
+# 50000: local object store
+# 50001: local scheduler
+# 60000: worker 0
+# 60001: worker 1
+# 60002: worker 2
+# and so on
+
+LOCAL_OBJECT_STORE_PORT = 50000
+LOCAL_SCHEDULER_PORT = 50001
+LOCAL_WORKER_PORT_START = 50002
+
+# for GCS:
+# 50000: function table
+# 50001: object table
+GCS_FUNCTION_TABLE_PORT = 50000
+GCS_OBJECT_TABLE_PORT = 50001

--- a/pythonserver/worker.py
+++ b/pythonserver/worker.py
@@ -9,6 +9,7 @@ import threading
 import os
 from datetime import datetime
 import cloudpickle as pickle
+from babyray import init, get, remote, Future
 
 from .constants import *
 
@@ -65,7 +66,7 @@ def init_all_stubs():
 
 class WorkerServer(rayclient_pb2_grpc.WorkerServicer):
     def __init__(self):
-        pass
+        init()
 
     def Run(self, request, context):
         global num_running_tasks, num_queued_tasks, average_running_time

--- a/pythonserver/worker.py
+++ b/pythonserver/worker.py
@@ -1,0 +1,152 @@
+# server-side implementation for Python-based worker server
+
+import grpc
+from concurrent import futures
+import time
+import base64
+import subprocess
+import threading
+import os
+from datetime import datetime
+import cloudpickle as pickle
+
+from .constants import *
+
+from . import rayclient_pb2
+from . import rayclient_pb2_grpc
+
+MAX_CONCURRENT_TASKS = 10
+EMA_PARAM = 0.9
+
+# Global variables
+semaphore = threading.Semaphore(MAX_CONCURRENT_TASKS)
+num_running_tasks = 0
+num_queued_tasks = 0
+average_running_time = 0.1
+mu = threading.Lock()
+
+MAX_MESSAGE_SIZE = 1024 * 1024 * 1024  # 1GB
+
+gcs_func_gRPC = None
+lobs_gRPC = None
+
+
+def local_log(*s):
+    # Get the current datetime
+    current_datetime = datetime.now()
+
+    # Format the datetime
+    formatted_datetime = current_datetime.strftime("%Y/%m/%d %H:%M:%S.%f")[:-3]
+
+    print(formatted_datetime, "[worker]", *s, flush=True)
+
+
+def init_all_stubs():
+    global gcs_func_gRPC, lobs_gRPC
+    channel_options = [
+        ("grpc.max_send_message_length", MAX_MESSAGE_SIZE),
+        ("grpc.max_receive_message_length", MAX_MESSAGE_SIZE),
+    ]
+
+    # so boilerplate-y
+    gcs_func_channel = grpc.insecure_channel(
+        f"node{GCS_NODE_ID}:{GCS_FUNCTION_TABLE_PORT}",
+        options=channel_options,
+    )
+    gcs_func_gRPC = rayclient_pb2_grpc.GCSFuncStub(gcs_func_channel)
+
+    lobs_channel = grpc.insecure_channel(
+        f"localhost:{LOCAL_OBJECT_STORE_PORT}", options=channel_options
+    )
+    lobs_gRPC = rayclient_pb2_grpc.LocalObjStoreStub(
+        lobs_channel,
+    )
+
+
+class WorkerServer(rayclient_pb2_grpc.WorkerServicer):
+    def __init__(self):
+        pass
+
+    def Run(self, request, context):
+        global num_running_tasks, num_queued_tasks, average_running_time
+
+        local_log("in Run() rn")
+
+        with mu:
+            num_queued_tasks += 1
+
+        with semaphore:
+            with mu:
+                num_queued_tasks -= 1
+                num_running_tasks += 1
+
+            try:
+                start = time.time()
+
+                func_response = gcs_func_gRPC.FetchFunc(
+                    rayclient_pb2.FetchRequest(name=request.name)
+                )
+                func_obj = pickle.loads(func_response.serializedFunc)
+                args_obj = pickle.loads(request.args)
+                kwargs_obj = pickle.loads(request.kwargs)
+
+                output = func_obj(*args_obj, **kwargs_obj)
+
+                output_pickled = pickle.dumps(output)
+                local_log("Executed!")
+
+                local_log("gonna store now")
+                lobs_gRPC.Store(
+                    rayclient_pb2.StoreRequest(
+                        uid=request.uid, objectBytes=output_pickled
+                    )
+                )
+                local_log("stored...")
+
+                running_time = time.time() - start
+                local_log(f"took this many seconds: {running_time:.3g}")
+
+                with mu:
+                    average_running_time = (
+                        EMA_PARAM * average_running_time
+                        + (1 - EMA_PARAM) * running_time
+                    )
+            finally:
+                with mu:
+                    num_running_tasks -= 1
+
+        return rayclient_pb2.StatusResponse(success=True)
+
+    def WorkerStatus(self, request, context):
+        global num_running_tasks, num_queued_tasks, average_running_time
+        # num_running_tasks, num_queued_tasks, average_running_time = 0, 0, 0.1
+
+        # local_log("HERES THE WORKER STATUS......... GONNA TRY TO ACQUIRE THE THING")
+        with mu:
+            # local_log("returning......>!!!!")
+            return rayclient_pb2.WorkerStatusResponse(
+                numRunningTasks=num_running_tasks,
+                numQueuedTasks=num_queued_tasks,
+                averageRunningTime=average_running_time,
+            )
+
+
+def serve():
+    init_all_stubs()
+
+    server = grpc.server(
+        # let's only start dropping requests 10x in
+        futures.ThreadPoolExecutor(max_workers=10 * MAX_CONCURRENT_TASKS)
+    )
+    # server = grpc.server()
+    rayclient_pb2_grpc.add_WorkerServicer_to_server(WorkerServer(), server)
+
+    server_address = "0.0.0.0:50002"
+    server.add_insecure_port(server_address)
+    local_log(f"Server listening on {server_address}")
+    server.start()
+    server.wait_for_termination()
+
+
+if __name__ == "__main__":
+    serve()

--- a/scripts/fig8a.py
+++ b/scripts/fig8a.py
@@ -33,7 +33,7 @@ def create_bytearr(n):
 
 @remote
 def dummy_func(fut):
-    bytearr = get(fut)
+    bytearr = get(fut, pickle_load=False)
 
     return 10
 
@@ -56,7 +56,9 @@ time.sleep(1)
 log("done with deploying sleepers")
 
 SIZES = [100_000, 1_000_000, 10_000_000, 100_000_000]
-NUM_TRIALS = 100
+# SIZES = [100_000_000]
+# SIZES = [10_000] * 4
+NUM_TRIALS = 10
 
 for size in SIZES:
     log("#" * 100)

--- a/scripts/fig8a.py
+++ b/scripts/fig8a.py
@@ -15,7 +15,7 @@ def log(*s):
     # Format the datetime
     formatted_datetime = current_datetime.strftime("%Y/%m/%d %H:%M:%S.%f")[:-3]
 
-    print(formatted_datetime, *s)
+    print(formatted_datetime, *s, flush=True)
 
 
 init()
@@ -61,20 +61,24 @@ NUM_TRIALS = 1
 log("running sleeper functions")
 for i in range(11):
     sleeper_func.remote()
+    log("wtf", i)
 
+log("done????")
 time.sleep(1)
 log("done with deploying sleepers")
 
 for i in range(NUM_TRIALS):
     # create an object either on node 3 or node 4
     # if random.random() < 0.5:
-    # create_bytearr.set_node(3)
+    create_bytearr.set_node(3)
     # else:
     #     create_bytearr.set_node(4)
 
-    # obj = create_bytearr.remote(BYTEARR_SIZE)
-    # start = time.time()
-    # get(obj, copy=False)  # block on this task
+    log("now actually creating the object...")
+    obj = create_bytearr.remote(BYTEARR_SIZE)
+    log("its created. now lets get it.")
+    start = time.time()
+    get(obj, copy=False)  # block on this task
     # time.sleep(2)
 
     start = time.time()

--- a/scripts/fig8a.py
+++ b/scripts/fig8a.py
@@ -1,0 +1,136 @@
+import sys
+from babyray import (
+    init,
+    remote,
+    get,
+    Future,
+)
+from datetime import datetime
+
+
+def log(*s):
+    # Get the current datetime
+    current_datetime = datetime.now()
+
+    # Format the datetime
+    formatted_datetime = current_datetime.strftime("%Y/%m/%d %H:%M:%S.%f")[:-3]
+
+    print(formatted_datetime, *s)
+
+
+init()
+
+# worker 1:
+# - create object #1
+# - schedule 10 sleeper tasks
+# - while True: time doing get(task(object #1)) or get(task(object #2))
+# worker 2:
+# - create object #2
+
+import time
+import random
+
+# 100KB to start
+# BYTEARR_SIZE = 100_000
+BYTEARR_SIZE = 200_000_000  # 100_000_000  # 100 MB
+
+
+# just create a local bytearray of size n
+@remote
+def create_bytearr(n):
+    return bytearray(n)
+
+
+@remote
+def dummy_func():
+    # bytearr = get(fut)
+
+    return 10
+
+
+@remote
+def sleeper_func():
+    time.sleep(999999)
+    return ""
+
+
+NUM_TRIALS = 1
+
+# sleeper functions are to ensure that any task we try to run will go to the
+# global scheduler first (instead of routed only locally)
+log("running sleeper functions")
+for i in range(11):
+    sleeper_func.remote()
+
+time.sleep(1)
+log("done with deploying sleepers")
+
+for i in range(NUM_TRIALS):
+    # create an object either on node 3 or node 4
+    # if random.random() < 0.5:
+    # create_bytearr.set_node(3)
+    # else:
+    #     create_bytearr.set_node(4)
+
+    # obj = create_bytearr.remote(BYTEARR_SIZE)
+    # start = time.time()
+    # get(obj, copy=False)  # block on this task
+    # time.sleep(2)
+
+    start = time.time()
+    out = get(dummy_func.remote())
+    elapsed = time.time() - start
+
+    log("elapsed time:", elapsed)
+
+# creating a byte array of size BYTEARR_SIZE on node 3
+# create_bytearr.set_node(3)
+# obj1 = create_bytearr.remote(BYTEARR_SIZE)
+# log("obj1", obj1)
+# time.sleep(1)
+
+# # creating a byte array of size BYTEARR_SIZE on node 4
+# log("creating obj2 now...")
+# create_bytearr.set_node(4)
+# obj2 = create_bytearr.remote(BYTEARR_SIZE)
+# log("obj2", obj2)
+# time.sleep(1)
+
+# queue a task that relies on this object. will be run randomly if
+# not locality-aware. will be run on the right node if locality-aware.
+
+# for i in range(10):
+#     start = time.time()
+#     fut = dummy_func.remote(obj1)
+#     log(get(fut))
+#     elapsed = time.time() - start
+#     log("elapsed time", elapsed)
+
+# for i in range(1):
+#     start = time.time()
+#     # if random.random() < 0.5:
+#     # obj_to_feed = obj1 if random.random() < 0.5 else obj2
+#     fut = dummy_func.remote(obj1)
+#     log("fut?", fut)
+
+#     get(fut)
+
+#     elapsed = time.time() - start
+
+#     log("time:", elapsed)
+# do the timer evaluation
+# for i in range(NUM_TRIALS):
+#     start = time.time()
+
+#     if random.random() < 0.5:
+#         get(dummy_func.remote(obj1))
+#     else:
+#         get(dummy_func.remote(obj2))
+
+#     elapsed = time.time() - start
+#     times.append(elapsed)
+
+# print("total time:", sum(times) / len(times))
+# with open("log.txt", "w") as f:
+#     for time in times:
+#         f.write(str(time) + ",")

--- a/scripts/fig8a.py
+++ b/scripts/fig8a.py
@@ -5,17 +5,7 @@ from babyray import (
     get,
     Future,
 )
-from datetime import datetime
-
-
-def log(*s):
-    # Get the current datetime
-    current_datetime = datetime.now()
-
-    # Format the datetime
-    formatted_datetime = current_datetime.strftime("%Y/%m/%d %H:%M:%S.%f")[:-3]
-
-    print(formatted_datetime, *s, flush=True)
+from utils import *
 
 
 init()

--- a/scripts/fig9.py
+++ b/scripts/fig9.py
@@ -28,30 +28,33 @@ MAX_TIME = 1.0  # just time 1 second at a time
 # ask for a node that is not ourself
 @remote
 def f(size):
-    return bytearray(size)
+    return bytearray(size * 1024)
 
 
-def get_iops(uid, max_time):
+def get_iops(size, max_time):
     counter = 0
     start = time.time()
     while time.time() - start < max_time:
-        get(uid)
+        get(f.remote(size), copy=False)
         counter += 1
 
     return counter
 
 
-NUM_TRIALS = 10
+NUM_TRIALS = 1
 sizes = [1, 10, 100, 1_000, 10_000, 100_000, 1_000_000]  # in KBs
 max_times = [1.0] * 4 + [5.0, 50, 5 * 60]
 f.set_node(2)
 for size in sizes:
     for i in range(NUM_TRIALS):
-        log("creating the object")
-        uid = f.remote(size)
-        get(uid, copy=False)  # block until it completes
-        log("object created")
-
-        iops = get_iops(uid, MAX_TIME) / MAX_TIME
+        # log("creating the object")
+        # uid = f.remote(size)
+        # get(uid, copy=False)  # block until it completes
+        # log("object created")
+        start = time.time()
+        get(f.remote(size), copy=False)
+        elapsed = time.time() - start
+        iops = 1 / elapsed
         thpt = iops * size
+
         log(f"RES:{size},{iops},{thpt}")

--- a/scripts/fig9.py
+++ b/scripts/fig9.py
@@ -1,0 +1,57 @@
+# pseudocode for Figure 9
+
+# server-side modifications needed:
+# - local scheduler and global scheduler should work at all
+# - local scheduler: should be able to shuttle not_client=True to global
+# - global scheduler: should be able to pick something that is not_client. doesn't matter how it's actually picked.
+# also, it doesn't seem like we actually need multiple VMs for this
+
+import sys
+from babyray import (
+    init,
+    remote,
+    get,
+    Future,
+)
+import random
+import time
+
+from utils import *
+
+init()
+
+# client-side code
+
+MAX_TIME = 1.0  # just time 1 second at a time
+
+
+# ask for a node that is not ourself
+@remote
+def f(size):
+    return bytearray(size)
+
+
+def get_iops(uid, max_time):
+    counter = 0
+    start = time.time()
+    while time.time() - start < max_time:
+        get(uid)
+        counter += 1
+
+    return counter
+
+
+NUM_TRIALS = 10
+sizes = [1, 10, 100, 1_000, 10_000, 100_000, 1_000_000]  # in KBs
+max_times = [1.0] * 4 + [5.0, 50, 5 * 60]
+f.set_node(2)
+for size in sizes:
+    for i in range(NUM_TRIALS):
+        log("creating the object")
+        uid = f.remote(size)
+        get(uid, copy=False)  # block until it completes
+        log("object created")
+
+        iops = get_iops(uid, MAX_TIME) / MAX_TIME
+        thpt = iops * size
+        log(f"RES:{size},{iops},{thpt}")

--- a/scripts/fig9.py
+++ b/scripts/fig9.py
@@ -28,7 +28,7 @@ MAX_TIME = 1.0  # just time 1 second at a time
 # ask for a node that is not ourself
 @remote
 def f(size):
-    return bytearray(size * 1024)
+    return bytearray(size)
 
 
 def get_iops(size, max_time):
@@ -41,8 +41,9 @@ def get_iops(size, max_time):
     return counter
 
 
-NUM_TRIALS = 1
+NUM_TRIALS = 3
 sizes = [1, 10, 100, 1_000, 10_000, 100_000, 1_000_000]  # in KBs
+sizes = [size * 1000 for size in sizes]
 max_times = [1.0] * 4 + [5.0, 50, 5 * 60]
 f.set_node(2)
 for size in sizes:
@@ -58,3 +59,5 @@ for size in sizes:
         thpt = iops * size
 
         log(f"RES:{size},{iops},{thpt}")
+
+log("DONE!")

--- a/scripts/run_fig8a.sh
+++ b/scripts/run_fig8a.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+# scripts/run_tests.sh
+
+# Build and run the tests
+# docker-compose build
+docker-compose -f docker-compose.yml -f docker-compose.fig8a.yml up
+
+# Wait for the services to be up and running
+sleep 20
+
+# Check the logs for the worker1 container to see if the tests passed
+docker-compose logs worker1 | tee output.log
+
+# Check if "All tests passed" is in the logs
+if grep -q "1 passed" output.log; then
+    echo "All tests passed!"
+    docker-compose down
+    exit 0
+else
+    echo "Some tests failed."
+    docker-compose down
+    exit 1
+fi

--- a/scripts/run_fig9.sh
+++ b/scripts/run_fig9.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+# scripts/run_tests.sh
+
+# Build and run the tests
+# docker-compose build
+docker-compose -f docker-compose.yml -f docker-compose.fig9.yml up
+
+# Wait for the services to be up and running
+sleep 20
+
+# Check the logs for the worker1 container to see if the tests passed
+docker-compose logs worker1 | tee output.log
+
+# Check if "All tests passed" is in the logs
+if grep -q "1 passed" output.log; then
+    echo "All tests passed!"
+    docker-compose down
+    exit 0
+else
+    echo "Some tests failed."
+    docker-compose down
+    exit 1
+fi

--- a/scripts/utils.py
+++ b/scripts/utils.py
@@ -1,0 +1,11 @@
+from datetime import datetime
+
+
+def log(*s):
+    # Get the current datetime
+    current_datetime = datetime.now()
+
+    # Format the datetime
+    formatted_datetime = current_datetime.strftime("%Y/%m/%d %H:%M:%S.%f")[:-3]
+
+    print(formatted_datetime, *s, flush=True)


### PR DESCRIPTION
Aiming for replication of Figure 8a and 9.

Fixes so far:
- increase max gRPC message size to 1GB.
- improve logging to be millisecond-precision timestamps
- calculate transfer time correctly (fix bandwidth calc. to division)
- fix numQueuedTasks = 1 when there is nothing queued but running task queue is full
- set default bandwidth to a non-zero value
- refactor LOBS so that all LocationFound() does is fill the channel. all parsing done on Get() side
	- related: implement no-copy get() so that we can just block on something instead of having to actually copy
- allow client to specify where to send a task
	- to make experimentation easier